### PR TITLE
Add warning on plugin installation if required dirs do not exist.

### DIFF
--- a/scripts/_Install.groovy
+++ b/scripts/_Install.groovy
@@ -1,8 +1,19 @@
 // Write the context.xml file in META-INF and WEB-INF
 def contextDotXml = """\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Context>
-    <Loader delegate=\"true\"/>
+    <Loader delegate="true"/>
 </Context>"""
-new File("$basedir/web-app/META-INF/context.xml").write contextDotXml
-new File("$basedir/web-app/WEB-INF/context.xml").write contextDotXml
+
+def webAppDir = new File(grailsSettings.baseDir, "web-app")
+def webInfDir = new File(webAppDir, "WEB-INF")
+def metaInfDir = new File(webAppDir, "META-INF")
+
+if (!webInfDir.exists())) {
+    event "StatusUpdate", [ "Your project does not have a 'web-app/WEB-INF' directory. Perhaps it's corrupt?" ]
+}
+
+webInfDir.mkdirs()
+metaInfDir.mkdirs()
+new File(webInfDir, "context.xml").write contextDotXml
+new File(metaInfDir, "context.xml").write contextDotXml


### PR DESCRIPTION
In the case where a project doesn't have web-app/WEB-INF or web-app/META-INF directories, the plugin installation causes an error, but without any information as to why it failed. This change adds a warning and then creates the required directories.
