### PR TITLE
Prune the description and correct the documentation URL in the plugin de...

### DIFF
--- a/EventsPushGrailsPlugin.groovy
+++ b/EventsPushGrailsPlugin.groovy
@@ -41,37 +41,16 @@ class EventsPushGrailsPlugin {
     def author = "Stephane Maldini"
     def authorEmail = "stephane.maldini@gmail.com"
     def description = '''\
-Events-push is a client-side events bus based on the portable push library Atmosphere and Grails platform-core plugin for events
-propagation/listening. It simply allows your client to listen to server-side events and push data. It uses WebSockets by default
-and failbacks to Comet method if required (server not compliant, browser too old...).
-Events-push is a white-list broadcaster (client-side events scope is 'browser'). You will need to define which events can be
- propagated to server by using Events DSL to use 'browser' scope. To register listeners from client, you will need to
- define them too. Ie:
+This is a client-side event bus based on the portable push library [Atmosphere|https://github.com/Atmosphere/atmosphere]\
+that propagates events from the server-side event bus provided by the [Platform Core|http://grails.org/plugin/platform-core]\
+to the browser. It allows your client Javascript code to both send events and listen for them.
 
-MyEvents.groovy >
-events = {
-    'saveTodo' scope:'*' // allows both server and client to send data over this topic
-    'savedTodo' browser:true // allows browser push on this topic
-}
-
-MyService.groovy >
-//will receive client events
-@Listener saveTodo(Map data){
-  ...
-  event('savedTodo', data) // will trigger registered browsers
-}
-
-someView.gsp >
-<r:require module="grailsEvents"/>
-<r:script>
- var grailsEvents = new grails.Events("http://localhost:8080/app/g-eventspush");
- grailsEvents.send('saveTodo', data); //will send data to server topic 'saveTodo'
- grailsEvents.on('savedTodo', function(data){...}); //will listen for server events on 'savedTodo' topic
-</r:script>
+For security, events-push is a white-list broadcaster so that you can control exactly which events are propagated from\
+the server to the browser.
 '''
 
     // URL to the plugin's documentation
-    def documentation = "http://grails.org/plugin/events-push"
+    def documentation = "https://github.com/smaldini/grails-events-push/blob/master/README.md"
 
     // Extra (optional) plugin metadata
 


### PR DESCRIPTION
...scriptor.

The existing description is too much like documentation, so I've attempted to cut it down to the core role of the plugin. Also updated the documentation URL, which now points to the README on GitHub.
