### PR TITLE
Support custom request attributes without loosing the information provided by grailsEvents

### DIFF
--- a/web-app/js/grails/grailsEvents.js
+++ b/web-app/js/grails/grailsEvents.js
@@ -86,8 +86,10 @@ var grails = grails || {};
                     }
 
                     localId = _localId;
-                    rq = jQuery.extend(rq, options);
-                    rq = jQuery.extend(rq, request);
+
+                    // Allow the user to extend/override the request
+                    rq = jQuery.extend(true, rq, options);
+                    rq = jQuery.extend(true, rq, request);
 
                     if (!that.globalTopicSocket) {
                         return socket.subscribe(rq);


### PR DESCRIPTION
When the deep flag is not set when calling jQuerys extend the user has to re-add the topic-header information by himself. This maybe a commons use case when trying to access custom request parameters in the browserFilter closure. 

```
grailsEvents.on('myTopic', function(data) {
 // consume response ...
}, {headers: {aUserToken: '1234'}});
```

Use deep flag when extending the request object created by grailsEvents
to allow the user to extend/override request attributes like headers
without loosing information provided by grailsEvents.
