### PR TITLE
removed hardcoded response content-type definition in the EventsPushHandler

### DIFF
--- a/src/java/org/grails/plugin/platform/events/push/EventsPushHandler.java
+++ b/src/java/org/grails/plugin/platform/events/push/EventsPushHandler.java
@@ -220,8 +220,6 @@ public class EventsPushHandler extends HttpServlet {
                 m.addListener(new AtmosphereResourceEventListenerAdapter());
         }
 
-        res.setContentType("application/javascript; charset=UTF-8");
-
         m.setBroadcaster(defaultBroadcaster);
 
         if (header != null && header.equalsIgnoreCase(HeaderConfig.LONG_POLLING_TRANSPORT)) {


### PR DESCRIPTION
removed hardcoded response content-type definition (application/javascript) because this broke streaming for internet explorer (asking to download eventbus.js instead of reading the streamed payload).

no problems with websockets in ff/chrome and no problems with streaming in ie/ff/chrome could be observed without that line. if i understood it correctly, atmosphere handles the browser specific content-type stuff anyways.
