### PR TITLE
add missing impl of new abstract method coming with atmosphere-2.x

### DIFF
--- a/src/java/org/grails/plugin/platform/events/push/BridgeWSListener.java
+++ b/src/java/org/grails/plugin/platform/events/push/BridgeWSListener.java
@@ -77,4 +77,10 @@ public class BridgeWSListener implements WebSocketEventListener, GrailsEventsAwa
 	public void onThrowable(AtmosphereResourceEvent event) {
 		//grailsEvents.event("onThrowable", event, SharedConstants.FROM_BROWSERS, null, null, null);
 	}
+
+	@Override
+	public void onClose(AtmosphereResourceEvent event) {
+		grailsEvents.event("onClose", event, EventsPushScopes.FROM_BROWSERS, null, null, null);
+	}
+	
 }


### PR DESCRIPTION
after upgrading to atmosphere-2.x _and_(!) a grails clean, this missing method impl (coming from abstract onClose(AtmosphereResourceEvent) in AtmosphereResourceEventListener) generates a compilation error
