### PR TITLE
Fix grailsEvents.js with jQuery noConflict

### DIFF
--- a/web-app/js/grails/grailsEvents.js
+++ b/web-app/js/grails/grailsEvents.js
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 var grails = grails || {};
-(function () {
+(function ($) {
     if (!grails.Events) {
         grails.Events = function (root, options) {
 
@@ -316,4 +316,4 @@ var grails = grails || {};
         grails.Events.CLOSED = 3;
 
     }
-})();
+})(jQuery);


### PR DESCRIPTION
I've added an small fix to prevent possible conflicts with the usage of $ for jQuery
