### PR TITLE
corrected typo when a user specifies an options.path option

### DIFF
--- a/web-app/js/grails/grailsEvents.js
+++ b/web-app/js/grails/grailsEvents.js
@@ -23,7 +23,7 @@ var grails = grails || {};
             var hasOptions = (options && (typeof options == "object"));
 
             that.globalTopicName = hasOptions && options.globalTopicName && (typeof options.globalTopicName == "string") ? options.globalTopicName : "eventsbus";
-            that.path = hasOptions && options.path && (typeof options.path == "string") ? option.path : "g-eventsbus";
+            that.path = hasOptions && options.path && (typeof options.path == "string") ? options.path : "g-eventsbus";
             that.binary = hasOptions && options.binary && (typeof options.binary == "boolean") ? options.binary : false;
 
             var loadingRequest = {};


### PR DESCRIPTION
I wanted to override the g-eventbus context path both on the client and the server.  Was able to override on the server, but the client has a typo which prevents me from specifying an override.
